### PR TITLE
fix(lists): delete associated content when removing a list

### DIFF
--- a/src/lists/list.service.ts
+++ b/src/lists/list.service.ts
@@ -214,9 +214,7 @@ export class ListsService {
       where: { list: { id: list.id } },
     });
     if (content) {
-      // Unlink list from content before deleting
-      content.list = null;
-      await this.contentRepository.save(content);
+      await this.contentRepository.remove(content);
     }
 
     return this.listRepository.remove(list);


### PR DESCRIPTION
When removeList was called directly, it only unlinked the content (set list = null + save) leaving the content orphaned in the DB. Now it removes the content entirely.