### PR TITLE
feat(content): add backlog flag with auto-sync from article/video status

### DIFF
--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -60,6 +60,7 @@ export class ArticlesService {
         type: ContentType.ARTICLE,
         authorId: createArticleDto.userId,
         articleId: savedArticle.id,
+        backlog: true,
       } as any);
     }
 
@@ -156,6 +157,7 @@ export class ArticlesService {
               type: ContentType.ARTICLE,
               authorId: assignedUser.id,
               articleId: id,
+              backlog: true,
             } as any);
             entity.content = newContent;
           } catch (error) {
@@ -168,6 +170,7 @@ export class ArticlesService {
           shouldSyncContent = true;
           contentId = content.id;
           contentSyncPayload.publicationDate = null;
+          contentSyncPayload.backlog = true;
         }
       } else if (updateArticleDto.status === ArticleStatus.PUBLISHED) {
         if (!updateArticleDto.updateDate) {
@@ -178,6 +181,7 @@ export class ArticlesService {
         entity.updateDate = new Date(updateArticleDto.updateDate);
         shouldSyncContent = true;
         contentSyncPayload.publicationDate = entity.updateDate;
+        contentSyncPayload.backlog = false;
       }
     }
 

--- a/src/contents/contents.controller.ts
+++ b/src/contents/contents.controller.ts
@@ -34,9 +34,10 @@ export class ContentsController {
   }
 
   @Get()
-  findAll(@Query('ready') ready?: string) {
+  findAll(@Query('ready') ready?: string, @Query('backlog') backlog?: string) {
     const isReady = ready === 'true' ? true : ready === 'false' ? false : undefined;
-    return this.contentsService.findAll(isReady);
+    const isBacklog = backlog === 'true' ? true : backlog === 'false' ? false : undefined;
+    return this.contentsService.findAll(isReady, isBacklog);
   }
 
   @Get(':id')

--- a/src/contents/contents.service.ts
+++ b/src/contents/contents.service.ts
@@ -294,11 +294,10 @@ export class ContentsService {
     return savedContent;
   }
 
-  async findAll(ready?: boolean): Promise<Content[]> {
+  async findAll(ready?: boolean, backlog?: boolean): Promise<Content[]> {
     const where: any = {};
-    if (ready !== undefined) {
-      where.ready = ready;
-    }
+    if (ready !== undefined) where.ready = ready;
+    if (backlog !== undefined) where.backlog = backlog;
     return this.contentRepo.find({
       where,
       relations: [

--- a/src/contents/dto/create-content.dto.ts
+++ b/src/contents/dto/create-content.dto.ts
@@ -55,4 +55,7 @@ export class CreateContentDto {
 
   @IsOptional()
   ready?: boolean;
+
+  @IsOptional()
+  backlog?: boolean;
 }

--- a/src/contents/entities/content.entity.ts
+++ b/src/contents/entities/content.entity.ts
@@ -77,4 +77,7 @@ export class Content {
 
   @Column({ default: false })
   ready: boolean;
+
+  @Column({ default: false })
+  backlog: boolean;
 }

--- a/src/migrations/1772642717355-AddBacklogToContent.ts
+++ b/src/migrations/1772642717355-AddBacklogToContent.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddBacklogToContent1772642717355 implements MigrationInterface {
+    name = 'AddBacklogToContent1772642717355'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "content" ADD "backlog" boolean NOT NULL DEFAULT false`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "content" DROP COLUMN "backlog"`);
+    }
+
+}

--- a/src/videos/videos.service.ts
+++ b/src/videos/videos.service.ts
@@ -79,6 +79,7 @@ export class VideosService {
         type: ContentType.VIDEO,
         authorId: createVideoDto.userId,
         videoId: savedEntity.id,
+        backlog: true,
       } as any);
     }
 
@@ -177,6 +178,7 @@ export class VideosService {
               type: ContentType.VIDEO,
               authorId: assignedUser.id,
               videoId: id,
+              backlog: true,
             } as any);
             entity.content = newContent;
           } catch (error) {
@@ -189,6 +191,7 @@ export class VideosService {
           shouldSyncContent = true;
           contentId = content.id;
           contentSyncPayload.publicationDate = null;
+          contentSyncPayload.backlog = true;
         }
       } else if (updateVideoDto.status === VideoStatusEnum.PUBLISHED) {
         if (!updateVideoDto.updateDate) {
@@ -199,6 +202,7 @@ export class VideosService {
         entity.updateDate = new Date(updateVideoDto.updateDate);
         shouldSyncContent = true;
         contentSyncPayload.publicationDate = entity.updateDate;
+        contentSyncPayload.backlog = false;
       }
     }
 


### PR DESCRIPTION
- Add backlog boolean field to Content entity (default false)
- Add backlog filter to GET /api/contents endpoint
- Auto-set backlog=true when article/video transitions to EDITING or READY
- Auto-set backlog=false when article/video transitions to PUBLISHED
- Add migration for backlog column