### PR TITLE
feat(articles): add coauthor field and include in userId filter

### DIFF
--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -42,6 +42,9 @@ export class ArticlesService {
       editor: createArticleDto.editorId
         ? { id: createArticleDto.editorId }
         : undefined,
+      coauthor: createArticleDto.coauthorId
+        ? { id: createArticleDto.coauthorId }
+        : undefined,
     });
     const savedArticle = await this.repo.save(entity);
 
@@ -69,33 +72,32 @@ export class ArticlesService {
   async findAll(params: FindArticleParams = {}): Promise<Article[]> {
     const { limit = 50, offset = 0, q, status, userId } = params;
 
-    const where: any = {};
+    const baseWhere: any = {};
 
-    if (userId) {
-      where.user = { id: userId };
-    }
+    if (status) baseWhere.status = status;
+    if (q) baseWhere.name = ILike(`%${q}%`);
 
-    if (status) {
-      where.status = status;
-    }
-
-    if (q) {
-      where.name = ILike(`%${q}%`);
-    }
+    const where = userId
+      ? [
+          { ...baseWhere, user: { id: userId } },
+          { ...baseWhere, editor: { id: userId } },
+          { ...baseWhere, coauthor: { id: userId } },
+        ]
+      : baseWhere;
 
     return this.repo.find({
       where,
       order: { updatedAt: 'DESC' },
       take: Math.min(Math.max(0, limit), 200),
       skip: Math.max(0, offset),
-      relations: ['user', 'content', 'editor'],
+      relations: ['user', 'content', 'editor', 'coauthor'],
     });
   }
 
   async findOne(id: string): Promise<Article> {
     const entity = await this.repo.findOne({
       where: { id },
-      relations: ['user', 'content', 'editor'],
+      relations: ['user', 'content', 'editor', 'coauthor'],
     });
     if (!entity) throw new NotFoundException('Article not found');
     return entity;
@@ -123,6 +125,10 @@ export class ArticlesService {
     // Handle User Assignment
     if (updateArticleDto.userId) {
       entity.user = { id: updateArticleDto.userId } as any;
+    }
+
+    if (updateArticleDto.coauthorId) {
+      entity.coauthor = { id: updateArticleDto.coauthorId } as any;
     }
 
     if (updateArticleDto.editorId) {

--- a/src/articles/dto/create-article.dto.ts
+++ b/src/articles/dto/create-article.dto.ts
@@ -28,4 +28,8 @@ export class CreateArticleDto {
     @IsUUID()
     @IsOptional()
     editorId?: string;
+
+    @IsUUID()
+    @IsOptional()
+    coauthorId?: string;
 }

--- a/src/articles/entities/article.entity.ts
+++ b/src/articles/entities/article.entity.ts
@@ -64,4 +64,7 @@ export class Article {
 
   @ManyToOne(() => User, { nullable: true })
   editor: User;
+
+  @ManyToOne(() => User, { nullable: true })
+  coauthor: User;
 }

--- a/src/migrations/1772644747040-AddCoauthorToArticle.ts
+++ b/src/migrations/1772644747040-AddCoauthorToArticle.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddCoauthorToArticle1772644747040 implements MigrationInterface {
+    name = 'AddCoauthorToArticle1772644747040'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "article" ADD "coauthorId" uuid`);
+        await queryRunner.query(`ALTER TABLE "article" ADD CONSTRAINT "FK_29740ddc0b7f0af9ed816db0f7a" FOREIGN KEY ("coauthorId") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "article" DROP CONSTRAINT "FK_29740ddc0b7f0af9ed816db0f7a"`);
+        await queryRunner.query(`ALTER TABLE "article" DROP COLUMN "coauthorId"`);
+    }
+
+}


### PR DESCRIPTION
- Add coauthor ManyToOne relation to Article entity
- Add coauthorId to CreateArticleDto
- Include coauthor in findAll, findOne relations
- userId filter now returns articles where user is author, editor or coauthor
- Add migration for coauthor column