### PR TITLE
fix(content): ensure backlog column exists with IF NOT EXISTS

### DIFF
--- a/src/migrations/1773143111542-EnsureBacklogOnContent.ts
+++ b/src/migrations/1773143111542-EnsureBacklogOnContent.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class EnsureBacklogOnContent1773143111542 implements MigrationInterface {
+    name = 'EnsureBacklogOnContent1773143111542'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "content"
+            ADD COLUMN IF NOT EXISTS "backlog" boolean NOT NULL DEFAULT false
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "content" DROP COLUMN IF EXISTS "backlog"`);
+    }
+}


### PR DESCRIPTION
Idempotent migration that adds the backlog column if it was not applied in production. Safe to run even if the column already exists.