### PR TITLE
feat(lastfm): add proxy endpoint GET /api/lastfm/artist?artist=name

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -17,3 +17,5 @@ SPOTIFY_CLIENT_SECRET=29a287ad6be04285ac8c589057638228
 
 R2_ACCESS_KEY_ID=your_r2_access_key_id
 R2_SECRET_ACCESS_KEY=your_r2_secret_access_key
+
+LASTFM_API_KEY=your_lastfm_api_key

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -33,6 +33,7 @@ import { UploadsModule } from './uploads/uploads.module';
 import { ExcelModule } from './excel/excel.module';
 import { RequestsModule } from './requests/requests.module';
 import { NationalReleasesModule } from './national-releases/national-releases.module';
+import { LastfmModule } from './lastfm/lastfm.module';
 
 @Module({
   imports: [
@@ -85,6 +86,7 @@ import { NationalReleasesModule } from './national-releases/national-releases.mo
     ExcelModule,
     RequestsModule,
     NationalReleasesModule,
+    LastfmModule,
   ],
 })
 export class AppModule {}

--- a/src/lastfm/lastfm.controller.ts
+++ b/src/lastfm/lastfm.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { LastfmService } from './lastfm.service';
+
+@Controller('lastfm')
+export class LastfmController {
+  constructor(private readonly lastfmService: LastfmService) {}
+
+  @Get('artist')
+  getArtistInfo(@Query('artist') artist: string) {
+    return this.lastfmService.getArtistInfo(artist);
+  }
+}

--- a/src/lastfm/lastfm.module.ts
+++ b/src/lastfm/lastfm.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { LastfmController } from './lastfm.controller';
+import { LastfmService } from './lastfm.service';
+
+@Module({
+  controllers: [LastfmController],
+  providers: [LastfmService],
+})
+export class LastfmModule {}

--- a/src/lastfm/lastfm.service.ts
+++ b/src/lastfm/lastfm.service.ts
@@ -1,0 +1,22 @@
+import { Injectable, BadRequestException, InternalServerErrorException } from '@nestjs/common';
+
+const LASTFM_BASE = 'https://ws.audioscrobbler.com/2.0/';
+
+@Injectable()
+export class LastfmService {
+  private readonly apiKey = process.env.LASTFM_API_KEY;
+
+  async getArtistInfo(artist: string): Promise<object> {
+    if (!this.apiKey) throw new InternalServerErrorException('LASTFM_API_KEY not configured');
+
+    const url = `${LASTFM_BASE}?method=artist.getinfo&artist=${encodeURIComponent(artist)}&api_key=${this.apiKey}&format=json`;
+
+    const res = await fetch(url);
+    if (!res.ok) throw new BadRequestException(`Last.fm responded with ${res.status}`);
+
+    const data = await res.json() as any;
+    if (data.error) throw new BadRequestException(data.message ?? 'Last.fm error');
+
+    return data.artist;
+  }
+}


### PR DESCRIPTION
Calls Last.fm artist.getinfo and returns artist object (bio.summary + tags). API key stored as LASTFM_API_KEY env var.