### PR TITLE
fix(throttler): increase rate limit to 60 req/min to prevent CORS-lik…

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -54,7 +54,7 @@ import { LastfmModule } from './lastfm/lastfm.module';
       synchronize: false,
       migrationsRun: true,
     }),
-    ThrottlerModule.forRoot([{ ttl: 60000, limit: 5 }]),
+    ThrottlerModule.forRoot([{ ttl: 60000, limit: 60 }]),
     I18nConfigModule,
     CommonModule,
 


### PR DESCRIPTION
…e errors

ThrottlerModule was blocking requests at 5/min, returning 429 without CORS headers, which the browser reported as a CORS error on login.