### PR TITLE
fix(logger): remove SolarWinds HTTP transport crashing the app

### DIFF
--- a/src/winston.config.ts
+++ b/src/winston.config.ts
@@ -37,26 +37,5 @@ export const winstonConfig = {
                 winston.format.json(),
             ),
         }),
-        new winston.transports.Http({
-            host: 'logs.collector.eu-01.cloud.solarwinds.com',
-            path: '/v1/logs',
-            ssl: true,
-            headers: {
-                Authorization: `Bearer fDK3DNFpJspyevqaNj8qev2rBzAML9Ha6eHt8G5tKbOZ8IQ5TM6RKNk4H_gy36q3lHXSct0`,
-            },
-            format: winston.format.combine(
-                winston.format.timestamp(),
-                winston.format((info) => {
-                    if (info && typeof info.level === 'string') {
-                        info['severity'] = info.level.toUpperCase();
-                    } else {
-                        // Fallback or skip
-                        info['severity'] = 'INFO';
-                    }
-                    return info;
-                })(),
-                winston.format.json(),
-            ),
-        }),
     ],
 };


### PR DESCRIPTION
Winston HTTP transport was emitting unhandled error events when SolarWinds endpoint failed, crashing Node with exit code 1 silently.