### PR TITLE
fix(discs): ensure every week contains at least one Friday

### DIFF
--- a/src/discs/discs.service.ts
+++ b/src/discs/discs.service.ts
@@ -781,13 +781,12 @@ export class DiscsService {
 
     let weekNum = 1;
 
-    // Week 1: days before the first Friday (if month doesn't start on Friday)
-    if (firstFriday > 1) {
-      weeks.push({ week: weekNum++, from: 1, to: firstFriday - 1 });
-    }
+    // Week 1: from day 1 through firstFriday+6 (pre-Friday days merged into first Friday week)
+    const firstWeekEnd = Math.min(firstFriday + 6, daysInMonth);
+    weeks.push({ week: weekNum++, from: 1, to: firstWeekEnd });
 
     // Remaining weeks: each starts on a Friday, runs 7 days
-    let start = firstFriday;
+    let start = firstFriday + 7;
     while (start <= daysInMonth) {
       weeks.push({ week: weekNum++, from: start, to: Math.min(start + 6, daysInMonth) });
       start += 7;


### PR DESCRIPTION
Merge pre-Friday days into week 1 instead of creating a separate week without a Friday. Trailing days at end of month are already handled by the existing Math.min logic.