### PR TITLE
feat(wordpress): embed Spotify single matching album track instead of…

### DIFF
--- a/src/lists/list.service.ts
+++ b/src/lists/list.service.ts
@@ -21,6 +21,7 @@ import { UpdateListDto } from './dto/update-list.dto';
 import { PaginationDto } from '../common/dtos/pagination.dto';
 import { Content } from 'src/contents/entities/content.entity';
 import { WordpressService } from 'src/wordpress/wordpress.service';
+import { SpotifyApiService } from 'src/wordpress/spotify-api.service';
 
 @Injectable()
 export class ListsService {
@@ -32,6 +33,7 @@ export class ListsService {
     @InjectRepository(Content)
     private readonly contentRepository: Repository<Content>,
     private readonly wordpressService: WordpressService,
+    private readonly spotifyApiService: SpotifyApiService,
   ) {}
 
   async create(createListDto: CreateListDto) {
@@ -622,7 +624,17 @@ export class ListsService {
       const title = `Nuevos discos - ${dateStr} (${roman})`;
       const seoTitle = `Nuevos discos ${day} de ${monthName} de ${year} (${roman}) • Riff Valley`;
       const seoDescription = `Nuevos discos de ${monthName} de ${year}: os recopilamos los lanzamientos de la semana del ${dateStr} que no te puedes perder.`;
-      const content = this.buildPostContent(discs, position, list, title);
+
+      const spotifyTrackIds = await Promise.all(
+        discs.map((a) =>
+          this.spotifyApiService.findSingleTrackForAlbum(
+            a.disc?.artist?.name ?? '',
+            a.disc?.name ?? '',
+          ),
+        ),
+      );
+
+      const content = this.buildPostContent(discs, position, list, title, spotifyTrackIds);
       const slug = `nuevos-discos${day}${month}${String(year).slice(-2)}${roman.toLowerCase()}`;
 
       const meta = {
@@ -645,7 +657,7 @@ export class ListsService {
     return { created: createdPosts.length, posts: createdPosts };
   }
 
-  private buildPostContent(discs: any[], position: number, list: any, title = ''): string {
+  private buildPostContent(discs: any[], position: number, list: any, title = '', spotifyTrackIds: (string | null)[] = []): string {
     const ordinals = ['Primera', 'Segunda', 'Tercera', 'Cuarta', 'Quinta'];
     const ordinal = ordinals[position - 1] ?? `${position}ª`;
 
@@ -696,8 +708,10 @@ export class ListsService {
 <div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->`;
 
+    const FALLBACK_TRACK_ID = '75EVwxItVYmK59hhfSsBoD';
+
     const discSections = discs
-      .map((a) => {
+      .map((a, i) => {
         const artist = a.disc?.artist?.name ?? '';
         const discName = a.disc?.name ?? '';
         const genre = a.disc?.genre?.name ?? 'xx';
@@ -715,8 +729,9 @@ export class ListsService {
 <!-- /wp:html -->`;
         }
 
+        const trackId = spotifyTrackIds[i] ?? FALLBACK_TRACK_ID;
         const spotifyEmbed = `\n\n<!-- wp:html -->
-<iframe data-testid="embed-iframe" style="border-radius:12px" src="https://open.spotify.com/embed/track/75EVwxItVYmK59hhfSsBoD?utm_source=generator" width="100%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+<iframe data-testid="embed-iframe" style="border-radius:12px" src="https://open.spotify.com/embed/track/${trackId}?utm_source=generator" width="100%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
 <!-- /wp:html -->`;
 
         const descriptionText = description ? ` ${description}` : '';

--- a/src/wordpress/spotify-api.service.ts
+++ b/src/wordpress/spotify-api.service.ts
@@ -1,0 +1,94 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class SpotifyApiService {
+  private readonly logger = new Logger('SpotifyApiService');
+  private readonly clientId: string;
+  private readonly clientSecret: string;
+  private accessToken: string | null = null;
+  private tokenExpiresAt = 0;
+
+  constructor(private readonly configService: ConfigService) {
+    this.clientId = this.configService.get<string>('SPOTIFY_CLIENT_ID', '');
+    this.clientSecret = this.configService.get<string>('SPOTIFY_CLIENT_SECRET', '');
+  }
+
+  private async getAccessToken(): Promise<string> {
+    if (this.accessToken && Date.now() < this.tokenExpiresAt) {
+      return this.accessToken;
+    }
+
+    const credentials = Buffer.from(`${this.clientId}:${this.clientSecret}`).toString('base64');
+    const res = await fetch('https://accounts.spotify.com/api/token', {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${credentials}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: 'grant_type=client_credentials',
+    });
+
+    if (!res.ok) throw new Error(`Spotify auth failed: ${res.status}`);
+
+    const data: any = await res.json();
+    this.accessToken = data.access_token;
+    this.tokenExpiresAt = Date.now() + (data.expires_in - 60) * 1000;
+    return this.accessToken;
+  }
+
+  private async get(path: string): Promise<any> {
+    const token = await this.getAccessToken();
+    const res = await fetch(`https://api.spotify.com/v1${path}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) {
+      this.logger.warn(`Spotify API ${path} → ${res.status}`);
+      return null;
+    }
+    return res.json();
+  }
+
+  async findSingleTrackForAlbum(artistName: string, albumName: string): Promise<string | null> {
+    try {
+      // 1. Buscar el álbum para obtener sus tracks
+      const albumSearch = await this.get(
+        `/search?q=album:${encodeURIComponent(albumName)}+artist:${encodeURIComponent(artistName)}&type=album&limit=1`,
+      );
+      const album = albumSearch?.albums?.items?.[0];
+      if (!album) return null;
+
+      const tracksData = await this.get(`/albums/${album.id}/tracks?limit=50`);
+      const albumTrackNames: string[] = (tracksData?.items ?? []).map((t: any) =>
+        t.name.toLowerCase(),
+      );
+      if (!albumTrackNames.length) return null;
+
+      // 2. Buscar singles del artista
+      const artistSearch = await this.get(
+        `/search?q=artist:${encodeURIComponent(artistName)}&type=artist&limit=1`,
+      );
+      const artist = artistSearch?.artists?.items?.[0];
+      if (!artist) return null;
+
+      const singlesData = await this.get(
+        `/artists/${artist.id}/albums?include_groups=single&market=ES&limit=50`,
+      );
+      const singles: any[] = singlesData?.items ?? [];
+
+      // 3. Cruzar singles con tracks del álbum
+      for (const single of singles) {
+        const singleTracks = await this.get(`/albums/${single.id}/tracks?limit=5`);
+        const match = (singleTracks?.items ?? []).find((t: any) =>
+          albumTrackNames.includes(t.name.toLowerCase()),
+        );
+        if (match) return match.id;
+      }
+
+      return null;
+    } catch (err) {
+      this.logger.error(`findSingleTrackForAlbum failed: ${err.message}`);
+      return null;
+    }
+  }
+}

--- a/src/wordpress/wordpress.module.ts
+++ b/src/wordpress/wordpress.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { WordpressService } from './wordpress.service';
+import { SpotifyApiService } from './spotify-api.service';
 
 @Module({
   imports: [ConfigModule],
-  providers: [WordpressService],
-  exports: [WordpressService],
+  providers: [WordpressService, SpotifyApiService],
+  exports: [WordpressService, SpotifyApiService],
 })
 export class WordpressModule {}


### PR DESCRIPTION
… hardcoded song

Adds SpotifyApiService that authenticates via client credentials and searches for a single by the same artist whose track name matches one from the album. Falls back to the generic track if no single is found.